### PR TITLE
Add Make.com scenario blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # mein-erster-agent
+
+This repository contains a basic Make.com scenario blueprint for creating a Google Calendar event from Vapi webhook data.
+
+## Scenario Overview
+
+1. Webhook module receives appointment data via HTTP POST from Vapi.
+2. Parse JSON module extracts timestamp, name and notes.
+3. Google Calendar module uses the parsed data to create a new calendar event.
+
+See `make_scenario_blueprint.json` for the placeholder setup.

--- a/make_scenario_blueprint.json
+++ b/make_scenario_blueprint.json
@@ -1,0 +1,39 @@
+{
+  "name": "Vapi to Google Calendar",
+  "modules": [
+    {
+      "module": "webhook",
+      "name": "Receive Vapi Webhook",
+      "settings": {
+        "url": "https://hook.make.com/your-webhook-id",
+        "method": "POST"
+      },
+      "description": "Custom webhook to receive appointment data"
+    },
+    {
+      "module": "tools.parseJson",
+      "name": "Parse JSON",
+      "settings": {
+        "json": "{{1.body}}"
+      },
+      "description": "Extract time, name and notes from the webhook payload"
+    },
+    {
+      "module": "google.calendar.createEvent",
+      "name": "Create Google Calendar Event",
+      "settings": {
+        "calendar_id": "your-calendar-id",
+        "summary": "{{2.name}}",
+        "start": "{{2.start_time}}",
+        "end": "{{2.end_time}}",
+        "description": "{{2.notes}}"
+      },
+      "description": "Creates event using data from Vapi"
+    }
+  ],
+  "connections": [
+    { "from": 1, "to": 2 },
+    { "from": 2, "to": 3 }
+  ],
+  "notes": "Replace placeholders with your actual webhook URL, calendar ID, and field mappings"
+}


### PR DESCRIPTION
## Summary
- add simple scenario blueprint for Make.com (formerly Integromat)
- document scenario setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684160e190848328a9e6b13fcb402af1